### PR TITLE
Add dependency module

### DIFF
--- a/bin/tdiary-mongodb-convert
+++ b/bin/tdiary-mongodb-convert
@@ -10,6 +10,7 @@ require 'tdiary/referer_manager'
 require 'tdiary/style'
 require 'tdiary/cache/file'
 require 'ostruct'
+require 'tdiary/core_ext'
 
 def load_diaries(data_path, style_path)
 	require 'tdiary/io/default'


### PR DESCRIPTION
いつも便利につかわせていただいています！

http://sho.tdiary.net/20150206.html#p01 に沿って自分の日記をherokuに置くのを試していたところ、 GFM スタイルの日記のインポート箇所で落ちる現象がありました。

内容を見てみたところ `lib/tdiary/io/default.rb` の263行目で次のような例外が発生していて

```
#<NoMethodError: undefined method `emojify' for "<h1>[gglog] gglog v0.0.2 をリリースした</h1>\n":String>
```

これによって日記本体が読み込めないでコメントの restore へと進んで、`lib/tdiary/io/default.rb` の45行目で `undefined method `add_comment' for nil:NilClass (NoMethodError)` が発生して落ちるというような事象であることがわかりました。

対処として適切かはわからないのですが、`emojify` が定義されている `'tdiary/core_ext'` を `bin/tdiary-mongodb-convert` で require することでうまくHerokuにインポートできましたので、PRしてみます。いかがでしょうか...??