### PR TITLE
upgrade mongoid 6.0 to support ruby2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,9 @@ language: ruby
 cache: bundler
 
 rvm:
-  - 2.0.0
-  - 2.1
   - 2.2
-  - 2.3.0
+  - 2.3.3
+  - 2.4.0
   - ruby-head
 
 before_install:

--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,4 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'tdiary', github: 'tdiary/tdiary-core'
+gem 'tdiary-style-rd'

--- a/tdiary-io-mongodb.gemspec
+++ b/tdiary-io-mongodb.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "tdiary-io-mongodb"
-  spec.version       = "4.2.0.1"
+  spec.version       = "5.0.3"
   spec.authors       = ["TADA Tadashi"]
   spec.email         = ["t@tdtds.jp"]
   spec.description   = %q{MongoDB adapter for tDiary}
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "mongoid", "~> 5.0"
+  spec.add_dependency "mongoid", "~> 6.0"
   spec.add_dependency "hikidoc"
 
   spec.add_development_dependency "bundler", "~> 1.3"


### PR DESCRIPTION
ruby2.4.0ではmongoid 5系が動かないので、6系にアップグレードしました。

動かない理由はmongoid5系がjson1.8.3に間接的に依存しており、json1.8.3がruby2.4.0に対応していないためです。 https://github.com/flori/json/issues/303 によると次のRails 4.2.8で対応するようですが、それをまたずにmongoidを上げてしまおうかと。

```
$ ebenv local 2.4.0
$ bundle
Fetching gem metadata from https://rubygems.org/........
Fetching version metadata from https://rubygems.org/.
Resolving dependencies...
（中略）
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /Users/machu/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/json-1.8.3/ext/json/ext/generator
/Users/machu/.rbenv/versions/2.4.0/bin/ruby -r ./siteconf20161229-75425-gs1efs.rb extconf.rb
creating Makefile

current directory: /Users/machu/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/json-1.8.3/ext/json/ext/generator
make "DESTDIR=" clean

current directory: /Users/machu/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/json-1.8.3/ext/json/ext/generator
make "DESTDIR="
compiling generator.c
generator.c:861:25: error: use of undeclared identifier 'rb_cFixnum'
    } else if (klass == rb_cFixnum) {
                        ^
generator.c:863:25: error: use of undeclared identifier 'rb_cBignum'
    } else if (klass == rb_cBignum) {
                        ^
2 errors generated.
make: *** [generator.o] Error 1

make failed, exit code 2

Gem files will remain installed in /Users/machu/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/json-1.8.3 for inspection.
Results logged to /Users/machu/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/extensions/x86_64-darwin-15/2.4.0-static/json-1.8.3/gem_make.out

An error occurred while installing json (1.8.3), and Bundler cannot continue.
Make sure that `gem install json -v '1.8.3'` succeeds before bundling.
```
