### PR TITLE
ignore failures of ruby head on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ rvm:
   - 2.5.0
   - ruby-head
 
+matrix:
+  allow_failures:
+    - rvm: ruby-head
+
 before_install:
   - gem update --system
   - gem update bundler


### PR DESCRIPTION
TravisCIでruby headが`LoadError: cannot load such file -- bundler/dep_proxy`というエラーを吐いているので、とりあえず様子見で結果を無視する(tdiary-coreでも同様の状況)。