### PR TITLE
optimize to generate calendar by aggregate function

### DIFF
--- a/lib/tdiary/io/mongodb.rb
+++ b/lib/tdiary/io/mongodb.rb
@@ -183,9 +183,15 @@ module TDiary
 			end
 
 			def calendar
+				mongo_project = {
+					"$group" => {
+						"_id" => {"year" => "$year", "month" => "$month"},
+						"count" => {"$sum" => 1}
+					}
+				}
 				calendar = Hash.new{|hash, key| hash[key] = []}
-				Diary.all.map{|d|[d.year, d.month]}.sort.uniq.each do |ym|
-					calendar[ym[0]] << ym[1]
+				Diary.collection.aggregate([mongo_project]).map do |cal|
+					calendar[cal['_id']['year']] = cal['_id']['month']
 				end
 				calendar
 			end

--- a/lib/tdiary/io/mongodb.rb
+++ b/lib/tdiary/io/mongodb.rb
@@ -191,7 +191,7 @@ module TDiary
 				}
 				calendar = Hash.new{|hash, key| hash[key] = []}
 				Diary.collection.aggregate([mongo_project]).map do |cal|
-					calendar[cal['_id']['year']] = cal['_id']['month']
+					calendar[cal['_id']['year']] << cal['_id']['month']
 				end
 				calendar
 			end


### PR DESCRIPTION
calendarの生成にDiaryコレクションをすべて舐める処理になっていて非常に時間がかかっていたので、Aggregateを使って最適化した。具体的にはDiaryコレクションの`year`と`month`でグループ化した結果を使う。