### PR TITLE
update supported ruby to 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,9 @@ language: ruby
 cache: bundler
 
 rvm:
-  - 2.3.8
-  - 2.4.5
-  - 2.5.3
-  - 2.6.0
+  - 2.6.7
+  - 2.7.3
+  - 3.0.1
   - ruby-head
 
 matrix:

--- a/tdiary-io-mongodb.gemspec
+++ b/tdiary-io-mongodb.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "mongoid", "~> 7.0"
-  spec.add_dependency "mongo", "< 2.9.0"
+  spec.add_dependency "mongoid", "~> 7.2"
+  spec.add_dependency "mongo", "~> 2.14"
   spec.add_dependency "hikidoc"
   spec.add_dependency "tdiary", ">= 5.0"
 


### PR DESCRIPTION
* サポートするrubyを整理。2.6、2.7、3.0をサポート
* 関連するgemもアップデート(主にmongo関連)